### PR TITLE
remove blank namespace. breaks example

### DIFF
--- a/example/10-module.yaml
+++ b/example/10-module.yaml
@@ -2,7 +2,6 @@ apiVersion: terraformcontroller.cattle.io/v1
 kind: Module
 metadata:
   name: my-module
-  namespace
 spec:
   git:
     url: https://github.com/dramich/domodule


### PR DESCRIPTION
`k create -f example/` was returning `error: error parsing example/10-module.yaml: error converting YAML to JSON: yaml: line 5: could not find expected ':'`