### PR TITLE
Change deployment to use apps/v1

### DIFF
--- a/manifests/10-deployment.yaml
+++ b/manifests/10-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
`apps/v1` has been supported since k8s 1.9+
Using this manifest on a 1.17 cluster is now failing for `apps/v1beta1` 