### PR TITLE
Update RestartPolicy on Job

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -17,7 +17,7 @@ RUN if [ "${ARCH}" == "amd64" ]; then \
         curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.15.0; \
     fi
 
-ENV K3S_VERSION v0.6.1
+ENV K3S_VERSION v1.18.3+k3s1
 #integration tests only support amd64
 RUN if [ "${ARCH}" == "amd64" ]; then \
         curl -sL https://github.com/rancher/k3s/releases/download/${K3S_VERSION}/k3s > /usr/bin/k3s \

--- a/pkg/terraform/state/deploy.go
+++ b/pkg/terraform/state/deploy.go
@@ -240,7 +240,7 @@ func (h *handler) createJob(or []metaV1.OwnerReference, input *Input, runName, r
 						},
 					},
 					NodeSelector:  nodeSelector,
-					RestartPolicy: "OnFailure",
+					RestartPolicy: "Never",
 				},
 			},
 		},

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -11,7 +11,7 @@ fi
 
 cd $(dirname $0)/..
 
-k3s server&
+k3s server --disable servicelb --disable traefik --disable local-storage --disable metrics-server&
 k3s_pid=$!
 
 kubeconfig=/etc/rancher/k3s/k3s.yaml


### PR DESCRIPTION
Update RestartPolicy for job to Never so as to help avoid pods being deleted.

This is due to the behavior of Kubernetes, namely
>Note: If your job has restartPolicy = "OnFailure", keep in mind that your container running the Job will be terminated once the job backoff limit has been reached. This can make debugging the Job's executable more difficult. We suggest setting restartPolicy = "Never" when debugging the Job or using a logging system to ensure output from failed Jobs is not lost inadvertently.

from https://kubernetes.io/docs/concepts/workloads/controllers/job/ 