### PR TITLE
update deployment manifest to v0.0.11-alpha1

### DIFF
--- a/manifests/10-deployment.yaml
+++ b/manifests/10-deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       serviceAccountName: terraform-controller
       containers:
-        - image: rancher/terraform-controller:v0.0.10-alpha1
+        - image: rancher/terraform-controller:v0.0.11-alpha1
           name: terraform-controller
           command: ["terraform-controller"]
           args: ["--namespace", "terraform-controller"]


### PR DESCRIPTION
Update the deployment manifest to pull the latest released version image for v0.0.11-alpha1
https://hub.docker.com/r/rancher/terraform-controller-executor/tags