### PR TITLE
Conditionally rerun executions

### DIFF
--- a/pkg/apis/terraformcontroller.cattle.io/v1/types.go
+++ b/pkg/apis/terraformcontroller.cattle.io/v1/types.go
@@ -10,6 +10,7 @@ var (
 	ModuleConditionGitUpdated = condition.Cond("GitUpdated")
 
 	StateConditionJobDeployed      = condition.Cond("JobDeployed")
+	StateConditionScheduled        = condition.Cond("RefreshScheduled")
 	ExecutionConditionMissingInfo  = condition.Cond("MissingInfo")
 	ExecutionConditionWatchRunning = condition.Cond("WatchRunning")
 	StateConditionDestroyed        = condition.Cond("Destroyed")
@@ -87,10 +88,11 @@ type StateSpec struct {
 }
 
 type StateStatus struct {
-	Conditions    []genericcondition.GenericCondition `json:"conditions,omitempty"`
-	LastRunHash   string                              `json:"lastRunHash,omitempty"`
-	ExecutionName string                              `json:"executionName,omitempty"`
-	StatePlanName string                              `json:"executionPlanName,omitempty"`
+	Conditions      []genericcondition.GenericCondition `json:"conditions,omitempty"`
+	RefreshSchedule metav1.Time                         `json:"schedule,omitempty"`
+	LastRunHash     string                              `json:"lastRunHash,omitempty"`
+	ExecutionName   string                              `json:"executionName,omitempty"`
+	StatePlanName   string                              `json:"executionPlanName,omitempty"`
 }
 
 // +genclient

--- a/pkg/terraform/state/deploy.go
+++ b/pkg/terraform/state/deploy.go
@@ -464,6 +464,11 @@ func generateRunHash(state *v1.State, vars map[string]string, h string, a string
 		fmt.Println("binary.Write failed:", err)
 	}
 
+	err = binary.Write(buf, binary.LittleEndian, state.Status.RefreshSchedule.Time.Unix())
+	if err != nil {
+		fmt.Println("binary.Write failed:", err)
+	}
+
 	hash := sha256.New()
 	if _, err := hash.Write([]byte(varHash)); err != nil {
 		logrus.Error("Failed to write to digest")


### PR DESCRIPTION
Sometimes we want to ensure real world matches desired state, if state
annotated with "terraformcontroller.cattle.io/run-every" timestamp will
be used to generate new runHash and state update will be scheduled

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>