### PR TITLE
Watch all namespaces

### DIFF
--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -219,7 +219,7 @@ func (e *E2E) getConfigMapEnv() *v1.ConfigMap {
 			Namespace: e.namespace,
 		},
 		Data: map[string]string{
-			"test_config_map_env": e.namespace,
+			"TF_VAR_test_config_map_env": e.namespace,
 		},
 	}
 }

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -19,16 +19,18 @@ import (
 )
 
 type E2E struct {
-	ctx        context.Context
-	cs         *kubernetes.Clientset
-	cfg        *rest.Config
-	kubeconfig string
-	namespace  string
-	moduleURL  string
-	crds       []crd.CRD
+	ctx           context.Context
+	cs            *kubernetes.Clientset
+	cfg           *rest.Config
+	kubeconfig    string
+	ctrlNamespace string
+	namespace     string
+	moduleUrl     string
+	name          string
+	crds          []crd.CRD
 }
 
-func NewE2E(namespace, kubeconfig, module string, crdsNames []string) *E2E {
+func NewE2E(name, namespace, kubeconfig, module string, crdsNames []string) *E2E {
 	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
 		logrus.Fatalf("Error building kubeconfig: %s", err.Error())
@@ -45,13 +47,15 @@ func NewE2E(namespace, kubeconfig, module string, crdsNames []string) *E2E {
 	}
 
 	return &E2E{
-		ctx:        signals.SetupSignalHandler(context.Background()),
-		cs:         cs,
-		cfg:        cfg,
-		kubeconfig: kubeconfig,
-		namespace:  namespace,
-		moduleURL:  module,
-		crds:       crds,
+		ctx:           signals.SetupSignalHandler(context.Background()),
+		cs:            cs,
+		cfg:           cfg,
+		kubeconfig:    kubeconfig,
+		ctrlNamespace: name,
+		namespace:     namespace,
+		name:          name,
+		moduleUrl:     module,
+		crds:          crds,
 	}
 }
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -17,7 +17,8 @@ import (
 )
 
 const (
-	Namespace     = "terraform-controller"
+	Name          = "terraform-controller"
+	Namespace     = "app"
 	ModuleURL     = "https://github.com/luthermonson/terraform-controller-test-module"
 	TestConfigMap = "test-config-map"
 )
@@ -35,7 +36,7 @@ func TestMain(m *testing.M) {
 		namespace = Namespace
 	}
 
-	e = NewE2E(namespace, kubeconfig, ModuleURL, []string{
+	e = NewE2E(name, namespace, kubeconfig, ModuleURL, []string{
 		"Module",
 		"State",
 		"Execution",

--- a/e2e/init_test.go
+++ b/e2e/init_test.go
@@ -37,25 +37,25 @@ func lowerPlural(s string) string {
 
 func TestGetNs(t *testing.T) {
 	assert := assert.New(t)
-	ns := e.getNs()
+	ns := e.getCtrlNs()
 	assert.Equal(reflect.TypeOf(ns), reflect.TypeOf(&corev1.Namespace{}))
-	assert.Equal(ns.ObjectMeta.Name, e.namespace)
+	assert.Equal(ns.ObjectMeta.Name, e.ctrlNamespace)
 }
 
 func TestGetSa(t *testing.T) {
 	assert := assert.New(t)
 	sa := e.getSa()
 	assert.Equal(reflect.TypeOf(sa), reflect.TypeOf(&corev1.ServiceAccount{}))
-	assert.Equal(sa.ObjectMeta.Name, e.namespace)
-	assert.Equal(sa.ObjectMeta.Namespace, e.namespace)
+	assert.Equal(sa.ObjectMeta.Name, e.name)
+	assert.Equal(sa.ObjectMeta.Namespace, e.ctrlNamespace)
 }
 
 func TestGetCrb(t *testing.T) {
 	assert := assert.New(t)
 	crb := e.getCrb()
 	assert.Equal(reflect.TypeOf(crb), reflect.TypeOf(&rbacv1.ClusterRoleBinding{}))
-	assert.Equal(crb.ObjectMeta.Name, e.namespace)
+	assert.Equal(crb.ObjectMeta.Name, e.name)
 	assert.Equal(crb.Subjects[0].Kind, "ServiceAccount")
-	assert.Equal(crb.Subjects[0].Name, e.namespace)
-	assert.Equal(crb.Subjects[0].Namespace, e.namespace)
+	assert.Equal(crb.Subjects[0].Name, e.name)
+	assert.Equal(crb.Subjects[0].Namespace, e.ctrlNamespace)
 }

--- a/main.go
+++ b/main.go
@@ -46,11 +46,6 @@ func main() {
 			Value:  "${HOME}/.kube/config",
 		},
 		cli.StringFlag{
-			Name:   "namespace",
-			EnvVar: "NAMESPACE",
-			Value:  "default",
-		},
-		cli.StringFlag{
 			Name:   "masterurl",
 			EnvVar: "MASTERURL",
 			Value:  "",
@@ -83,9 +78,8 @@ func run(c *cli.Context) {
 
 	threadiness := c.Int("threads")
 	masterurl := c.String("masterurl")
-	ns := c.String("namespace")
 
-	logrus.Printf("Booting Terraform Controller, namespace: %s", ns)
+	logrus.Println("Booting Terraform Controller")
 
 	ctx := signals.SetupSignalHandler(context.Background())
 
@@ -94,22 +88,22 @@ func run(c *cli.Context) {
 		logrus.Fatalf("Error building kubeconfig: %s", err.Error())
 	}
 
-	tfFactory, err := terraformcontroller.NewFactoryFromConfigWithNamespace(cfg, ns)
+	tfFactory, err := terraformcontroller.NewFactoryFromConfig(cfg)
 	if err != nil {
 		logrus.Fatalf("Error building terraform controllers: %s", err.Error())
 	}
 
-	coreFactory, err := core.NewFactoryFromConfigWithNamespace(cfg, ns)
+	coreFactory, err := core.NewFactoryFromConfig(cfg)
 	if err != nil {
 		logrus.Fatalf("Error building core controllers: %s", err.Error())
 	}
 
-	rbacFactory, err := rbac.NewFactoryFromConfigWithNamespace(cfg, ns)
+	rbacFactory, err := rbac.NewFactoryFromConfig(cfg)
 	if err != nil {
 		logrus.Fatalf("Error building rbac controllers: %s", err.Error())
 	}
 
-	batchFactory, err := batch.NewFactoryFromConfigWithNamespace(cfg, ns)
+	batchFactory, err := batch.NewFactoryFromConfig(cfg)
 	if err != nil {
 		logrus.Fatalf("Error building rbac controllers: %s", err.Error())
 	}

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -37,7 +37,6 @@ k3s ctr images import --base-name terraform-controller-executor artifacts/images
 k3s kubectl rollout status deployment coredns -n kube-system # make sure coredns is actually running
 
 export KUBECONFIG=$kubeconfig
-export NAMESPACE=terraform-controller
 
 ./bin/terraform-controller --threads 1&
 tfc_pid=$!


### PR DESCRIPTION
* Drop namespace option
* Change e2e in a way controller and objects are splitted into separate
  namespaces.

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>